### PR TITLE
Update install/uninstall target actions to match directory structure

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -358,22 +358,21 @@ install: marley
 	mkdir -p $(DESTDIR)$(incdir)/marley
 	mkdir -p $(DESTDIR)$(datadir)/marley
 	cp marley $(MAYBE_MARSUM) $(DESTDIR)$(bindir)
+	cp marley-config $(DESTDIR)$(bindir)
 	cp $(SHARED_LIB) $(DESTDIR)$(libdir)
 	cp $(ROOT_SHARED_LIB) $(DESTDIR)$(libdir) 2> /dev/null || true
 	cp marley_root_dict_rdict.pcm $(DESTDIR)$(libdir) 2> /dev/null || true
-	cp -r ../react $(DESTDIR)$(datadir)/marley
-	cp -r ../structure $(DESTDIR)$(datadir)/marley
+	cp -r ../data $(DESTDIR)$(datadir)/marley
 	cp -r ../examples $(DESTDIR)$(datadir)/marley
 	cp -r ../include/marley $(DESTDIR)$(incdir)
-	ldconfig
 
 uninstall:
 	$(RM) $(DESTDIR)$(bindir)/marley
 	$(RM) $(DESTDIR)$(bindir)/marsum
 	$(RM) $(DESTDIR)$(bindir)/mroot
+	$(RM) $(DESTDIR)$(bindir)/marley-config
 	$(RM) $(DESTDIR)$(libdir)/$(SHARED_LIB)
 	$(RM) $(DESTDIR)$(libdir)/$(ROOT_SHARED_LIB)
 	$(RM) $(DESTDIR)$(libdir)/marley_root_dict_rdict.pcm
 	$(RM) -r $(DESTDIR)$(datadir)/marley
 	$(RM) -r $(DESTDIR)$(incdir)/marley
-	ldconfig


### PR DESCRIPTION
In "install" target, replace separate copying of react/ and structure/ directories to copying data/ directory.  Copy marley-config as well, so it is available to users.  Remove `ldconfig` action in both "install" and "uninstall": requires `sudo` privileges to write into /etc.